### PR TITLE
niv nixpkgs: update b839d4a8 -> a371c107

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b839d4a8557adc80e522f674529e586ab2a88d23",
-        "sha256": "1yr68sj0wx78fw4xi0swhlwbmqbznd5c1klmshqrrdclnr45agcd",
+        "rev": "a371c1071161104d329f6a85d922fd92b7cbab63",
+        "sha256": "1k5wa16wyb1byk5xfjlq4m518gsw6g1kypx4xb09k3inni13p0r4",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/b839d4a8557adc80e522f674529e586ab2a88d23.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/a371c1071161104d329f6a85d922fd92b7cbab63.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks.nix": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Commits: [nixos/nixpkgs@b839d4a8...a371c107](https://github.com/nixos/nixpkgs/compare/b839d4a8557adc80e522f674529e586ab2a88d23...a371c1071161104d329f6a85d922fd92b7cbab63)

* [`c857365a`](https://github.com/NixOS/nixpkgs/commit/c857365a7cf53c690492eed0431a94aa147de785) cpp-utilities: 5.7.0 -> 5.8.0
* [`23c932f8`](https://github.com/NixOS/nixpkgs/commit/23c932f8792b46b3303b7d66b99fe6c5e4970211) ctop: 0.7.4 -> 0.7.5
* [`5b3f7b23`](https://github.com/NixOS/nixpkgs/commit/5b3f7b23ff2024c08e954cf7dde020e2448d4c63) dnsproxy: 0.32.6 -> 0.33.2
* [`79709873`](https://github.com/NixOS/nixpkgs/commit/79709873e3534d2e739b3ff8f22a9ada93fad6f3) do-agent: 3.7.1 -> 3.8.0
* [`a4e0d2b1`](https://github.com/NixOS/nixpkgs/commit/a4e0d2b1b83df0ea77c143ff342c33e6b9f50c8b) doctest: 2.4.0 -> 2.4.1
* [`2fe0a921`](https://github.com/NixOS/nixpkgs/commit/2fe0a921a4408ca712400042c8b4a9ee3bd96083) doctl: 1.49.0 -> 1.51.0
* [`50124398`](https://github.com/NixOS/nixpkgs/commit/5012439804f39272648d39da9a4d7b68e81a8bd6) dolt: 0.21.1 -> 0.21.4
* [`14ed5891`](https://github.com/NixOS/nixpkgs/commit/14ed5891eb5da6f92795d582a42f65a9bd043147) doppler: 3.16.0 -> 3.16.1
* [`9a7d633b`](https://github.com/NixOS/nixpkgs/commit/9a7d633b59f754a81fce55e3556cf23d0aac6f33) dstask: 0.23 -> 0.23.1
* [`faa1d785`](https://github.com/NixOS/nixpkgs/commit/faa1d785f68495e883c495caa22cd6ad429c935d) duckdb: 0.2.1 -> 0.2.2
* [`070cf26f`](https://github.com/NixOS/nixpkgs/commit/070cf26fe8432e467f84844231f88ce606447a8a) duf: 0.4.0 -> 0.5.0
* [`d3fc9d74`](https://github.com/NixOS/nixpkgs/commit/d3fc9d7499ea57d27a38b012667bf43d693b2502) duperemove: 0.11.1 -> 0.11.2
* [`ee702dac`](https://github.com/NixOS/nixpkgs/commit/ee702dac70ac1d667ccc58017de71b4059727497) ergo: 3.3.5 -> 3.3.6
* [`17c9e6f2`](https://github.com/NixOS/nixpkgs/commit/17c9e6f2ffe1db856987967dd8a3afaac6c09eb0) exoscale-cli: 1.19.0 -> 1.20.2
* [`49bd6654`](https://github.com/NixOS/nixpkgs/commit/49bd6654cfb6ba69631513aaa2e297055296dbd2) gnome3.mutter334: Use full sysprof
* [`9b9cf946`](https://github.com/NixOS/nixpkgs/commit/9b9cf9469ffad6c98efa980c4e12ea6d3fee4e06) python3Packages.tensorboardx: fix build after upgrade to PyTorch 1.6
* [`88894b56`](https://github.com/NixOS/nixpkgs/commit/88894b56921ab388ac17e21943ba1952ab53b2ee) fluent-bit: 1.6.2 -> 1.6.3
* [`9d408eb8`](https://github.com/NixOS/nixpkgs/commit/9d408eb8341468b874f10ab49ebf34fffd8bd8c3) flyctl: 0.0.145 -> 0.0.146
* [`a23aa390`](https://github.com/NixOS/nixpkgs/commit/a23aa390c519e6ec089c21a0a18f7360f78d3e82) python37Packages.google_cloud_automl: 2.0.0 -> 2.1.0
* [`b331d9f9`](https://github.com/NixOS/nixpkgs/commit/b331d9f9c95a482b32c4e19adf35958f444286c5) azure-storage-azcopy: 10.6.1 -> 10.7.0
* [`78889211`](https://github.com/NixOS/nixpkgs/commit/7888921107f15b988f7c3d8ce38c143328ad98eb) tmuxp: 1.5.8 -> 1.6.2
* [`e787afe7`](https://github.com/NixOS/nixpkgs/commit/e787afe7eddfcb61d075e477bb806820ffa13ae8) python27Packages.rope: 0.17.0 -> 0.18.0
* [`2e6b0235`](https://github.com/NixOS/nixpkgs/commit/2e6b023570a278d4edbc4d720703ca21b6e57fef) postfix: 3.5.6 -> 3.5.7
* [`8d4e04cb`](https://github.com/NixOS/nixpkgs/commit/8d4e04cb557d8a187b2f345e8af9144fb2537a64) qtractor: 0.9.15 -> 0.9.18
* [`df76f017`](https://github.com/NixOS/nixpkgs/commit/df76f017f21e95659622b0b364dc0730e5fcafd7) python37Packages.snowflake-connector-python: 2.3.4 -> 2.3.5
* [`af2f6c21`](https://github.com/NixOS/nixpkgs/commit/af2f6c21d9c51872a829061274d33c513866ec30) frp: 0.34.1 -> 0.34.2
* [`d2264a55`](https://github.com/NixOS/nixpkgs/commit/d2264a55529be20ea78f31a20ee5339e3e08f57b) ft2-clone: 1.37 -> 1.39
* [`b24bccf5`](https://github.com/NixOS/nixpkgs/commit/b24bccf5366c3b1983903373eff77d99240b6f36) qmmp: 1.4.1 -> 1.4.2
* [`195ed0d5`](https://github.com/NixOS/nixpkgs/commit/195ed0d5cdb861268b49e28857a22d2c1391e950) gauge: 1.1.4 -> 1.1.5
* [`a9e2cea8`](https://github.com/NixOS/nixpkgs/commit/a9e2cea85c85587efc8344736d00eda3de9fe64c) gifski: 1.2.2 -> 1.2.4
* [`c945b47a`](https://github.com/NixOS/nixpkgs/commit/c945b47a25d4fa0c0ac342291b2142eb9807a746) linuxPackages.wireguard: fix the build on linux 5.4.76
* [`8e9b7713`](https://github.com/NixOS/nixpkgs/commit/8e9b77130da43189be22c8ac07545f04a7d1dc6f) globalarrays: 5.7.2 -> 5.8
* [`d16b0de9`](https://github.com/NixOS/nixpkgs/commit/d16b0de92dd3e6e40847eed3c1bb07fbb563581c) goconst: 1.2.0 -> 1.3.2
* [`27a11e95`](https://github.com/NixOS/nixpkgs/commit/27a11e95b397ecd7b2d638049003c44875ed38d5) golangci-lint: 1.32.0 -> 1.32.2
* [`0aefa1ed`](https://github.com/NixOS/nixpkgs/commit/0aefa1ed8a330f94f0a5590927de02c38ed39a57) gramps: 5.0.1 -> 5.1.3
* [`4c875b9c`](https://github.com/NixOS/nixpkgs/commit/4c875b9c025e7cd7b9ee0ae5ccd7314bc4d6717d) wrangler: fix Darwin build
* [`85d4895f`](https://github.com/NixOS/nixpkgs/commit/85d4895f0986c2f9f5585daaf365d87a0c86cb64) hcloud: 1.19.1 -> 1.20.0
* [`be92f5f0`](https://github.com/NixOS/nixpkgs/commit/be92f5f0d610726d557c99d08bac3799b1f3e022) helmfile: 0.132.1 -> 0.134.0
* [`13c4f38c`](https://github.com/NixOS/nixpkgs/commit/13c4f38c80cfc4921bae9cfe8e097e0e3305551b) helmsman: 3.4.6 -> 3.5.1
* [`6fe3b7c9`](https://github.com/NixOS/nixpkgs/commit/6fe3b7c9df47005eeecc4cecc3a10dc50a7f76c4) hugo: 0.78.0 -> 0.78.1
* [`ef13cb68`](https://github.com/NixOS/nixpkgs/commit/ef13cb68b1b80ef41713c4c5ac9a43e54740fa86) humioctl: 0.27.0 -> 0.28.1
* [`87d5e6fc`](https://github.com/NixOS/nixpkgs/commit/87d5e6fc1adc56c3fb2b731e4183c6fd0c6a75a8) Change idiom for overriding Dhall package version
* [`9b5b1d2b`](https://github.com/NixOS/nixpkgs/commit/9b5b1d2bfa8edfd18935c5b8965712c0d9a389f1) jackett: 0.16.1964 -> 0.16.2131
* [`fe1568fa`](https://github.com/NixOS/nixpkgs/commit/fe1568fa24106e01b056845010f2ad6ce5fd108f) nextcloud-client: remove myself from the maintainer list
* [`fba4c99f`](https://github.com/NixOS/nixpkgs/commit/fba4c99f4f211f041f66c7e584ed3362aac2555f) davfs2: 1.5.6 -> 1.6.0
* [`3f41f8b2`](https://github.com/NixOS/nixpkgs/commit/3f41f8b24e6b47a45c0e983a08213e420074dbd1) unison: 2.51.2 -> 2.51.3
* [`292de46c`](https://github.com/NixOS/nixpkgs/commit/292de46c5b9c3f42088d3de0d74a2aedf3755fee) Document conventions around adding new maintainers
* [`11114dac`](https://github.com/NixOS/nixpkgs/commit/11114dac1063c4395e031da761797fd0a764eed8) portfolio: 0.49.0 -> 0.49.2
* [`999e24d2`](https://github.com/NixOS/nixpkgs/commit/999e24d2472213a76e549beb9a823fe380b70483) vista-fonts: new sha256
* [`aa96bd29`](https://github.com/NixOS/nixpkgs/commit/aa96bd294b2ce9852a524e1a88dad2bd50852a0f) gimpPlugins: include GIMP into the scope
* [`e39bc29e`](https://github.com/NixOS/nixpkgs/commit/e39bc29e1ec8e5ec450037b4884edd469e164b9c) asciigraph: init at 0.5.1 (nixos/nixpkgs#103184)
* [`cfbe7995`](https://github.com/NixOS/nixpkgs/commit/cfbe7995dea49e744bcf6b4aa431d158db1464e0) lightburn: 0.9.16 -> 0.9.18
* [`193e8bc7`](https://github.com/NixOS/nixpkgs/commit/193e8bc722727f61763b88d1ecf444c0d7cf1f92) knot-dns: 3.0.1 -> 3.0.2
* [`ca9dcfb1`](https://github.com/NixOS/nixpkgs/commit/ca9dcfb1c4f77e9e01a732282ab437873d6843c7) lokalise2-cli: 2.6.0 -> 2.6.1
* [`ef990c19`](https://github.com/NixOS/nixpkgs/commit/ef990c190598106d6c795f136c78d71c7e35ecaf) oh-my-zsh: 2020-11-09 → 2020-11-10
* [`3be8a448`](https://github.com/NixOS/nixpkgs/commit/3be8a4483a69961aae6b1404f8a3b64b04d99b0f) linux_latest-libre: 17744 -> 17762
* [`8e364d51`](https://github.com/NixOS/nixpkgs/commit/8e364d518b34d0b4aca0b6e3079afa9c0b527ea3) linux/hardened/patches/4.14: 4.14.204.a -> 4.14.205.a
* [`362d24c7`](https://github.com/NixOS/nixpkgs/commit/362d24c7ee13d70bab71002f8f417fe3f06f706f) linux/hardened/patches/4.19: 4.19.155.a -> 4.19.156.a
* [`7420461d`](https://github.com/NixOS/nixpkgs/commit/7420461d12fe55603a9493fb2251889e5f7b3232) linux/hardened/patches/5.4: 5.4.75.a -> 5.4.76.a
* [`e7fa508f`](https://github.com/NixOS/nixpkgs/commit/e7fa508f85e000f9f98b43fdb2e82b9f0909744b) linux/hardened/patches/5.9: 5.9.6.a -> 5.9.7.a
* [`e4d8eb1c`](https://github.com/NixOS/nixpkgs/commit/e4d8eb1c300a80deb057590a85a1ea15117321ee) sbt-extras: Add update script
* [`6134eafe`](https://github.com/NixOS/nixpkgs/commit/6134eafe085685ff22796e250127a8c70424b183) sbt-extras: 2020-09-24 → 2020-11-08
* [`b9c505b7`](https://github.com/NixOS/nixpkgs/commit/b9c505b7bf909180f69a0a03f42656a3c44e21f8) sbt-extras: Add test
* [`0251996c`](https://github.com/NixOS/nixpkgs/commit/0251996c69b9d57b5234f9549075b9de269d13d1) lsof: 4.93.2 -> 4.94.0
* [`280e2732`](https://github.com/NixOS/nixpkgs/commit/280e27327d4990245d418cd10a9d14cfd6df6f05) knot-resolver: 5.1.3 -> 5.2.0
* [`7bbff896`](https://github.com/NixOS/nixpkgs/commit/7bbff896df9c426b00126d810279079f5afd27ac) androidStudioPackages.stable: 4.1.0.19 -> 4.1.1.0
* [`e66ba6bd`](https://github.com/NixOS/nixpkgs/commit/e66ba6bd4619068541dd0446e2c69f2a7cba08a2) gst_all_1.gst-plugins-bad: fix build on Darwin
* [`dd7b6a51`](https://github.com/NixOS/nixpkgs/commit/dd7b6a5160fa8ad3eee3445e979cbbc2ba75f059) pythonPackages.py-multihash: 0.2.3 -> 1.0.0
* [`0effabb3`](https://github.com/NixOS/nixpkgs/commit/0effabb377ce29b9cc815cf650ef647b2da98ef7) musikcube: 0.93.1 -> 0.94.0
* [`60e9a17a`](https://github.com/NixOS/nixpkgs/commit/60e9a17a5ae6a952f767ee39e8ddbd41a75a010e) intel-media-driver: 2.4.0 -> 2.4.1
* [`63fc8c77`](https://github.com/NixOS/nixpkgs/commit/63fc8c77ca4ae5c36b02572ada9409d74f571be9) openethereum: v3.0.1 -> v3.1.0
* [`d7e7fb7e`](https://github.com/NixOS/nixpkgs/commit/d7e7fb7e7d1704a69f45085fa2a314f2bc7de1df) geant4: 10.6.2 -> 10.6.3 (nixos/nixpkgs#103095)
* [`e8226dbe`](https://github.com/NixOS/nixpkgs/commit/e8226dbef06dfe13913f60f7efbe4e13f686231f) nfpm: 1.8.0 -> 1.10.0
* [`ffe4dbf3`](https://github.com/NixOS/nixpkgs/commit/ffe4dbf32f4335d9a8f7fc124ff7614fb9413363) nixos/tests/zfs: Test boot.zfs.forceImportAll
* [`a4010e05`](https://github.com/NixOS/nixpkgs/commit/a4010e0580fed8afe7d3d5cb53c3b2319c718792) nixos/zfs: Respect forceImportAll in import service
* [`e0d51db4`](https://github.com/NixOS/nixpkgs/commit/e0d51db401a64b7e69f10bde7221c1d27bed29dc) nixos: boot.zfsImportAll = false; by default
* [`c360d971`](https://github.com/NixOS/nixpkgs/commit/c360d971a29778aa6ff309c27ff1d6acd8f6209d) nix-build-uncached: 1.0.2 -> 1.1.0
* [`14a6cf25`](https://github.com/NixOS/nixpkgs/commit/14a6cf25dba1ac87748706e591acc79c08603a91) trash-cli: 0.17.1.14 -> 0.20.11.7
* [`d277dc65`](https://github.com/NixOS/nixpkgs/commit/d277dc65a1f36f9f63bcfd0e77f28568231eee37) turbo-geth: init at 2020.11.01
* [`8446b342`](https://github.com/NixOS/nixpkgs/commit/8446b3425516c88696c77cc6feae155144029e37) grafana: 7.3.1 -> 7.3.2
* [`83992fd7`](https://github.com/NixOS/nixpkgs/commit/83992fd7c6f93ce1310db4eca9c2cc053a9d0b37) bisoncpp: init (nixos/nixpkgs#103316)
* [`49b6ce8c`](https://github.com/NixOS/nixpkgs/commit/49b6ce8ce7ef9815a80ab04fac62553cfcba268a) tempo: 0.2.0 -> 0.3.0
* [`a3aa03f3`](https://github.com/NixOS/nixpkgs/commit/a3aa03f32951b5eb125da27cf07eb5581a678f5a) oneDNN: 1.6.4 -> 1.7
* [`a3bf66f4`](https://github.com/NixOS/nixpkgs/commit/a3bf66f4872fd5250a9d4a33080f640d3d242bd3) quisk: init at 4.1.72
* [`88b7340a`](https://github.com/NixOS/nixpkgs/commit/88b7340a79751b648d0f8c4339587464b5918595) doc: Fix doc-building instructions
* [`380337da`](https://github.com/NixOS/nixpkgs/commit/380337da106cca58932154e4ea04dc1b64703a04) terraform: withPlugins should inherit meta from wrapped derivation (nixos/nixpkgs#103396)
* [`5c8be438`](https://github.com/NixOS/nixpkgs/commit/5c8be438ead5c0bda138f95d569d356567349bc0) packet-cli: 0.0.8 -> 0.1.1
* [`7741f925`](https://github.com/NixOS/nixpkgs/commit/7741f925f16e26ab9c601291337e3efb46d00dec) google-cloud-cpp: remove myself from maintainers
* [`f24b6959`](https://github.com/NixOS/nixpkgs/commit/f24b695908339c783ebf119f4c87416d2b00cd1f) pdfcpu: 0.3.6 -> 0.3.7
* [`5d3b3554`](https://github.com/NixOS/nixpkgs/commit/5d3b355469a0a8c20197b76795b3087943e8bf7c) pgmetrics: 1.10.0 -> 1.10.2
* [`d7688900`](https://github.com/NixOS/nixpkgs/commit/d7688900b4274a71b783813a7cef85be4b291a7a) oh-my-zsh: 2020-11-10 → 2020-11-11
* [`399acdc9`](https://github.com/NixOS/nixpkgs/commit/399acdc93405018e63925fde1fd9c89dbee5290c) linux: 4.14.205 -> 4.14.206
* [`08a59efe`](https://github.com/NixOS/nixpkgs/commit/08a59efe79fcc90cf1de30f2080df1d45c471668) linux: 4.19.156 -> 4.19.157
* [`f4ce75d9`](https://github.com/NixOS/nixpkgs/commit/f4ce75d98d04baf73ac02a2046fc32a025e63a2a) linux: 4.4.242 -> 4.4.243
* [`3b27759e`](https://github.com/NixOS/nixpkgs/commit/3b27759e52b8f25c054decc36b63d690c768ee64) linux: 4.9.242 -> 4.9.243
* [`193f7a49`](https://github.com/NixOS/nixpkgs/commit/193f7a49feeb449ded34c1be439c776d30fa5d74) linux: 5.4.76 -> 5.4.77
* [`470f86b8`](https://github.com/NixOS/nixpkgs/commit/470f86b85195b41147afb814d8320117a00b824b) linux: 5.9.7 -> 5.9.8
* [`6322425d`](https://github.com/NixOS/nixpkgs/commit/6322425d0c05258b3591dc7eb4c8c11a68a503bc) linux/hardened/patches/4.14: 4.14.205.a -> 4.14.206.a
* [`7bfbd07c`](https://github.com/NixOS/nixpkgs/commit/7bfbd07c06cc792c9f31e01394de1231b372f7b0) linux/hardened/patches/4.19: 4.19.156.a -> 4.19.157.a
* [`feab1992`](https://github.com/NixOS/nixpkgs/commit/feab19926f2c9a7d7f127ce754d0a5587e181d1c) linux/hardened/patches/5.4: 5.4.76.a -> 5.4.77.a
* [`413237b4`](https://github.com/NixOS/nixpkgs/commit/413237b4edcabede6dab53664c4d051d4c1d109f) linux/hardened/patches/5.9: 5.9.7.a -> 5.9.8.a
* [`d6af8fd0`](https://github.com/NixOS/nixpkgs/commit/d6af8fd0dcd9e9c4b9aadb471a87302b334c0954) bluespec maintainer flokli -> jcumming (nixos/nixpkgs#103487)
* [`ac35114c`](https://github.com/NixOS/nixpkgs/commit/ac35114c8946bce220240942db1e10542373e922) qrencode: 4.0.2 -> 4.1.1
* [`a73467d0`](https://github.com/NixOS/nixpkgs/commit/a73467d0aa099550a05788ac95b9e66296a76bcf) procs: 0.10.5 -> 0.10.7
* [`11c8a6e4`](https://github.com/NixOS/nixpkgs/commit/11c8a6e4f73cb9b70cd0e873e0d5d70c25d91ccc) vagrant: 2.2.11 -> 2.2.13
* [`b7df5235`](https://github.com/NixOS/nixpkgs/commit/b7df52351afd11521ccdfce66eb00ef408548937) python27Packages.colorlog: 4.2.1 -> 4.4.0
* [`7e0dc8e3`](https://github.com/NixOS/nixpkgs/commit/7e0dc8e35e13adcf75ed37afa7258f85331f9a6f) pure-prompt: 1.13.0 -> 1.15.0
* [`d7f38d2f`](https://github.com/NixOS/nixpkgs/commit/d7f38d2fcc726d4327b340d3f6f8966801b64b76) dt-schema: 2020.8.1 -> 2020.11
* [`dcab9048`](https://github.com/NixOS/nixpkgs/commit/dcab90488ca74c77164a5ba2f2464219d83dffbd) dasm: 2.20.14 -> 2.20.14.1
* [`855fc08b`](https://github.com/NixOS/nixpkgs/commit/855fc08b1b6f76d709b2bb292299d03b7bc9e0c9) gqrx: 2.13.2 -> 2.13.5
* [`473f39b6`](https://github.com/NixOS/nixpkgs/commit/473f39b65bacc6eeb14142454c596614e5b9cb6b) k9s: 0.23.3 -> 0.23.10
* [`03b81ea8`](https://github.com/NixOS/nixpkgs/commit/03b81ea8293a60d191ee01ab85cd288009b37ac0) pipenv: 2020.8.13 -> 2020.11.4
* [`51a1f280`](https://github.com/NixOS/nixpkgs/commit/51a1f280b480d055eccfb51671202d67c488514e) qpdf: 10.0.1 -> 10.0.3
* [`145f20d1`](https://github.com/NixOS/nixpkgs/commit/145f20d1e729b3ab3730ac5c250e3087eb8ba00c) catch2: 2.13.2 -> 2.13.3
* [`eb6a8495`](https://github.com/NixOS/nixpkgs/commit/eb6a8495cef6f1af30cc13605dff3b3900da357f) kubelogin: 0.0.6 -> 0.0.7
* [`019c3bb4`](https://github.com/NixOS/nixpkgs/commit/019c3bb417153a2b80f483891f7f0981f6d327a8) pistol: 0.1.4 -> 0.1.7
* [`db0db5c0`](https://github.com/NixOS/nixpkgs/commit/db0db5c09ff7dca3651424c6fd5b3f46d92af6fa) netatalk: remove glibc input
* [`b3c6aac6`](https://github.com/NixOS/nixpkgs/commit/b3c6aac659a2cd75636d2ee04b3d8f9f6701a108) polkadot: 0.8.26 -> 0.8.26-1
* [`aec6a806`](https://github.com/NixOS/nixpkgs/commit/aec6a8069f91b9ed6a85c8dd8dc646e8afdd4a65) pcm: 202009 -> 202010
* [`19484b9f`](https://github.com/NixOS/nixpkgs/commit/19484b9f57249977a3f2fc4200a5f492f9ba3f43) pythonPackages.gtts-token: 1.1.3 -> 1.1.4
* [`4c4538cd`](https://github.com/NixOS/nixpkgs/commit/4c4538cd63bc06c4513cc82e3cfc626344c908e3) homeassistant: 0.117.5 -> 0.117.6
* [`41f90a81`](https://github.com/NixOS/nixpkgs/commit/41f90a81c71c872aa861941429e1114ac6bdfd56) faudio: 20.10 -> 20.11
* [`21bc6aaf`](https://github.com/NixOS/nixpkgs/commit/21bc6aaf19b0fe585bf0f4df63b77179d8c3fb54) pgcenter: 0.6.5 -> 0.6.6
* [`a52b343b`](https://github.com/NixOS/nixpkgs/commit/a52b343b39716017ee3fddc15b4de8ed28341928) oxipng: 3.0.1 -> 4.0.0
* [`79d04a7c`](https://github.com/NixOS/nixpkgs/commit/79d04a7cdb2c1b72d19a65c0c46a6ed2babb048a) onefetch: 2.7.0 -> 2.7.1
* [`6109d8bc`](https://github.com/NixOS/nixpkgs/commit/6109d8bc04103b5a2ea87bf6be50031531d71cba) mutagen: 0.11.7 -> 0.11.8
* [`1e53f7e1`](https://github.com/NixOS/nixpkgs/commit/1e53f7e10be36f6b89ded4504067213c26e670bd) gitAndTools.gh: 1.2.0 -> 1.2.1
* [`32584c45`](https://github.com/NixOS/nixpkgs/commit/32584c4561f6bd331a8a6b60666205082da97e05) livepeer: 0.5.11 -> 0.5.12
* [`97bba96b`](https://github.com/NixOS/nixpkgs/commit/97bba96ba463d932c5ed97e2da21824f35b34192) rar2fs: 1.29.1 -> 1.29.2
* [`a2e71c49`](https://github.com/NixOS/nixpkgs/commit/a2e71c49e68c3d5424f9df5c1e7a02cfcdbd03fb) vscode-extensions.scala-lang.scala: 0.3.8 -> 0.4.5
* [`8281820c`](https://github.com/NixOS/nixpkgs/commit/8281820c96651de93b37563971d17506b1d721af) vscode-extensions.scalameta.metals: 1.9.4 -> 1.9.6
* [`5420cb29`](https://github.com/NixOS/nixpkgs/commit/5420cb2904667a473cc13e0a02c5ee023333f293) metals: 0.9.4 -> 0.9.5
* [`fa1165d7`](https://github.com/NixOS/nixpkgs/commit/fa1165d700eb23f0e01d9d5a39f7fd262cca0595) nanoflann: 1.3.1 -> 1.3.2
* [`e84ac7ff`](https://github.com/NixOS/nixpkgs/commit/e84ac7ff3bc9b38ec9348d947e4b119b26ccb7e2) nanoflann: remove extra whitespace
* [`f7485d07`](https://github.com/NixOS/nixpkgs/commit/f7485d07b58001870ed713616dc2d4cfb879c3f6) lean: 3.21.0 -> 3.23.0
* [`7fad6685`](https://github.com/NixOS/nixpkgs/commit/7fad668515dc13f7c32215827cf75e00808c423b) bloop: 1.4.4 -> 1.4.5
* [`c112ab2f`](https://github.com/NixOS/nixpkgs/commit/c112ab2f1d564d1500a780313f80660665fb8525) dotnetCorePackages.net_5_0: init at version 5.0.0
* [`a3604fc3`](https://github.com/NixOS/nixpkgs/commit/a3604fc39d87d3384dc5b0cded27f0a413d8bbcd) dotnetCorePackages.aspnetcore_5_0: init at version 5.0.0
* [`e60fc2ca`](https://github.com/NixOS/nixpkgs/commit/e60fc2ca56ca3aad77d42818839529fe12fcbcf3) dotnetCorePackages.sdk_5_0: 5.0.100-rc.1.20452.10 -> 5.0.100
* [`a94cc8dc`](https://github.com/NixOS/nixpkgs/commit/a94cc8dc921112051cd477e4ded922acfd254fbe) dotnet: document new net packages
* [`67a986a4`](https://github.com/NixOS/nixpkgs/commit/67a986a44aaf31e3e38a838c39cf55a7581db263) rr: 5.3.0 -> 5.4.0
* [`d3a30145`](https://github.com/NixOS/nixpkgs/commit/d3a30145c34cb86ecb9f55066414a4401bbacdee) Make maintainer documentation more direct (nixos/nixpkgs#103455)
* [`a56626b6`](https://github.com/NixOS/nixpkgs/commit/a56626b64567a780a32e80de39633d99c9586aa7) rtsp-simple-server: 0.10.0 -> 0.12.0
* [`35d25643`](https://github.com/NixOS/nixpkgs/commit/35d2564325c47f2e087baeb174574dd860ff5ef4) saml2aws: 2.27.0 -> 2.27.1
* [`ec26da1f`](https://github.com/NixOS/nixpkgs/commit/ec26da1fc6e54e60b71b4a2dd2e429a3f7b9183e) nixos/acpilight: add to packages
* [`3f20417b`](https://github.com/NixOS/nixpkgs/commit/3f20417b4cbdb108228c098167698bec7208b6bf) doc/*: fix indentation
* [`31051812`](https://github.com/NixOS/nixpkgs/commit/31051812bc4117d394966f5df240de531a747809) nixos/doc/*: fix indentation
* [`ccbcbe27`](https://github.com/NixOS/nixpkgs/commit/ccbcbe27b3d5158dedacd165320318581faa010b) jcumming -> add github and githubId
* [`abeb10d2`](https://github.com/NixOS/nixpkgs/commit/abeb10d2f7fce2b4d83b529cf9b4e3e697f80974) syncthingtray: 1.0.0 -> 1.0.1
* [`28bc8ead`](https://github.com/NixOS/nixpkgs/commit/28bc8eadd10fe19d30479f4f034d57dbac017a20) ocrmypdf: 11.0.1 -> 11.3.3, fix build
* [`5a512241`](https://github.com/NixOS/nixpkgs/commit/5a5122418ae3f4c7cafaa867915826afda3a5b5d) python310: 3.10.0a1 -> 3.10.0a2
* [`ee455912`](https://github.com/NixOS/nixpkgs/commit/ee4559129a93fcac2dacd63cbfe7988ac1b95993) compcert: remove annoying assertions
