### PR TITLE
niv home-manager: update 4cc1b77c -> fd79015c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4cc1b77c3fc4f4b3bc61921dda72663eea962fa3",
-        "sha256": "02y6bjakcbfc0wvf9b5qky792y9abyf1kgnk8r30f1advn3x69nc",
+        "rev": "fd79015c0feee0e61e17f6ed59b4e9d01d9ef597",
+        "sha256": "157hiimhmkr28zb2jpxmsfrnz5j3s3zk142h6w4h1q75v8xhhbzg",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/4cc1b77c3fc4f4b3bc61921dda72663eea962fa3.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/fd79015c0feee0e61e17f6ed59b4e9d01d9ef597.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
## Changelog for home-manager:
Commits: [nix-community/home-manager@4cc1b77c...fd79015c](https://github.com/nix-community/home-manager/compare/4cc1b77c3fc4f4b3bc61921dda72663eea962fa3...fd79015c0feee0e61e17f6ed59b4e9d01d9ef597)

* [`fd79015c`](https://github.com/nix-community/home-manager/commit/fd79015c0feee0e61e17f6ed59b4e9d01d9ef597) home-manager: pass `-j` to nix-build
