### PR TITLE
niv NUR: update 34bad844 -> 92e3307c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "34bad8441dd62c28332c3fb76baabb6a9a96594f",
-        "sha256": "136dy4mkgrn11p2i8a5nnymhj3bk1wpfkbrji60ayq28srd2ypj8",
+        "rev": "92e3307c840eb007b22c0f2b8e11c248cfba8df8",
+        "sha256": "1kmqfq6wh59hdjpx6hdhs7l76carmzcsk2rqlm8xw5nz279ycqaw",
         "type": "tarball",
-        "url": "https://github.com/nix-community/NUR/archive/34bad8441dd62c28332c3fb76baabb6a9a96594f.tar.gz",
+        "url": "https://github.com/nix-community/NUR/archive/92e3307c840eb007b22c0f2b8e11c248cfba8df8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "home-manager": {


### PR DESCRIPTION
## Changelog for NUR:
Commits: [nix-community/NUR@34bad844...92e3307c](https://github.com/nix-community/NUR/compare/34bad8441dd62c28332c3fb76baabb6a9a96594f...92e3307c840eb007b22c0f2b8e11c248cfba8df8)

* [`9a5617c2`](https://github.com/nix-community/NUR/commit/9a5617c2461bc72ce48734029fa96de93d241f3f) automatic update
* [`75294b65`](https://github.com/nix-community/NUR/commit/75294b6598e8d52da183e8e9fb5402f38cd0c1bc) automatic update
* [`56cc4cc2`](https://github.com/nix-community/NUR/commit/56cc4cc20b559adaa584490f5a20c82170ef5195) automatic update
* [`dc8905b3`](https://github.com/nix-community/NUR/commit/dc8905b3d42581f9d53765a77c9aa88751440471) automatic update
* [`4f89ebcc`](https://github.com/nix-community/NUR/commit/4f89ebcc84a26a9916397fcea17ef18385395e56) automatic update
* [`6bde526d`](https://github.com/nix-community/NUR/commit/6bde526d291ae3730296519ac12e0312d6859e6e) automatic update
* [`92e3307c`](https://github.com/nix-community/NUR/commit/92e3307c840eb007b22c0f2b8e11c248cfba8df8) automatic update
