### PR TITLE
niv home-manager: update 9c14bbe9 -> b04aa565

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9c14bbe988f4a085863b3f39e0215109dc446485",
-        "sha256": "0ahxf581p7375xhwn6ajps44f27chyqzbnvv8lmhv93g68k4bcrc",
+        "rev": "b04aa56503c59d07a72361dfe9845c3ab2faac1b",
+        "sha256": "0rlfsn5r573kx1azdsxvhcnjq3sh93gyjlrbm79qv7bh3vizsm5k",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/9c14bbe988f4a085863b3f39e0215109dc446485.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/b04aa56503c59d07a72361dfe9845c3ab2faac1b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
## Changelog for home-manager:
Commits: [nix-community/home-manager@9c14bbe9...b04aa565](https://github.com/nix-community/home-manager/compare/9c14bbe988f4a085863b3f39e0215109dc446485...b04aa56503c59d07a72361dfe9845c3ab2faac1b)

* [`234de027`](https://github.com/nix-community/home-manager/commit/234de0270a3540be5661cbcc3d957a4952e02823) broot: improve configuration
* [`f3372bf9`](https://github.com/nix-community/home-manager/commit/f3372bf98270c3982a97c79fa1f854dec41b1499) kakoune: use a plugin with smaller closure size in test
* [`b3fdbfdf`](https://github.com/nix-community/home-manager/commit/b3fdbfdf422df2508ad16336ac0fc0ffaa40d0ee) git: use `gitMinimal` in test
* [`cde1d33e`](https://github.com/nix-community/home-manager/commit/cde1d33e6149e671fda33b6b6a9f43552a38c5fa) sway: remove test dependency on xwayland
* [`b04aa565`](https://github.com/nix-community/home-manager/commit/b04aa56503c59d07a72361dfe9845c3ab2faac1b) powerline-go: add zsh integration
