### PR TITLE
niv nixpkgs: update a371c107 -> 2deeb58f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a371c1071161104d329f6a85d922fd92b7cbab63",
-        "sha256": "1k5wa16wyb1byk5xfjlq4m518gsw6g1kypx4xb09k3inni13p0r4",
+        "rev": "2deeb58f49480f468adca6b08291322de4dbce6b",
+        "sha256": "0fx2car6dcd1yz6jjkifcan0amwzhs3170h0r69k0wfwiaadpvjv",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/a371c1071161104d329f6a85d922fd92b7cbab63.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/2deeb58f49480f468adca6b08291322de4dbce6b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks.nix": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Commits: [nixos/nixpkgs@a371c107...2deeb58f](https://github.com/nixos/nixpkgs/compare/a371c1071161104d329f6a85d922fd92b7cbab63...2deeb58f49480f468adca6b08291322de4dbce6b)

* [`24aedc9a`](https://github.com/NixOS/nixpkgs/commit/24aedc9a1437a048fb14386010e6a0f6bda6b74b) perlPackages: init Catalyst::Authentication::Store::LDAP at 1.016 (and dependencies)
* [`de5875a4`](https://github.com/NixOS/nixpkgs/commit/de5875a4d3f8dcf2ceb9dbc65baf9019fc1b49af) libcef: 74.1.14 -> 75.1.14
* [`f0d31b3b`](https://github.com/NixOS/nixpkgs/commit/f0d31b3bd16e47009337b6e5fe3b36ae70dbcb46) obs-studio: Enable builtin browser support
* [`cbcb8418`](https://github.com/NixOS/nixpkgs/commit/cbcb8418746ee98598bcec0e8a8442531ad129a4) Remove obs-linuxbrowser
* [`7aa50bb3`](https://github.com/NixOS/nixpkgs/commit/7aa50bb38ba24dc6b1116152c85b15638ba5f542) maintainers: add dbirks
* [`6c9aaf2a`](https://github.com/NixOS/nixpkgs/commit/6c9aaf2a811720a4a9ec603116314f39c22cd636) makemkv: fix formatting and replace pkgconfig alias
* [`83e9cc41`](https://github.com/NixOS/nixpkgs/commit/83e9cc41f62dbdce06c62c82276f6c5a0afa0097) makemkv: add jre_headless PATH through the wrapper
* [`e7ce7e37`](https://github.com/NixOS/nixpkgs/commit/e7ce7e370abc8a709d3e01068f8c52450924d3d9) ssmsh: init at 1.4.3
* [`e940b82a`](https://github.com/NixOS/nixpkgs/commit/e940b82ab7959b4d254264f6cc266a654a520119) bambootracker: 0.4.4 -> 0.4.5
* [`4735ed0d`](https://github.com/NixOS/nixpkgs/commit/4735ed0d4ff973daf71c00027c90db1348ed875c) perlPackages.FutureAsyncAwait: 0.45 -> 0.46
* [`a126b440`](https://github.com/NixOS/nixpkgs/commit/a126b44084c4394da875f588d12466603f6e8019) terragrunt: 0.25.5 -> 0.26.2
* [`a79902f2`](https://github.com/NixOS/nixpkgs/commit/a79902f23e9c84a0b6c389f75a91f103e1ef0e5e) microcodeIntel: 20200616 -> 20201110
* [`5eb3f97e`](https://github.com/NixOS/nixpkgs/commit/5eb3f97e5700297c834d7e5211708d429bffeec8) joplin-desktop: 1.2.6 -> 1.3.18
* [`f72a3142`](https://github.com/NixOS/nixpkgs/commit/f72a3142f07352b326906a2cd609e311d77ef555) doc: 20.09 release notes: nixos-YY.MM branches no longer in nixos-channels repo
* [`a431ca04`](https://github.com/NixOS/nixpkgs/commit/a431ca04631b5af2090a392c8482e72a7fc23c2f) rss-bridge: 2020-02-26 -> 2020-11-10
* [`33645572`](https://github.com/NixOS/nixpkgs/commit/33645572206e3b4f1401a39f95181d8ee7b6b0d6) sd-local: 1.0.5 -> 1.0.12
* [`e859317c`](https://github.com/NixOS/nixpkgs/commit/e859317c39e639d93b33ea26df4a1896f3cf0eb7) seaweedfs: 2.07 -> 2.09
* [`1e8e9f6b`](https://github.com/NixOS/nixpkgs/commit/1e8e9f6b7cdd63d7cec50135d5063b6d906406de) simplenote: 1.21.1 -> 2.0.0
* [`7bf14060`](https://github.com/NixOS/nixpkgs/commit/7bf1406091a36265ef2d9ac1179cc985a4ab85bf) skaffold: 1.15.0 -> 1.16.0
* [`a1c9c430`](https://github.com/NixOS/nixpkgs/commit/a1c9c430bf340a7b5170be853cf3261ba7afadb0) drumstick: fix plugin lookup and enable SonivoxEAS and FluidSynth plugins
* [`fd9f28c3`](https://github.com/NixOS/nixpkgs/commit/fd9f28c396f4cb22da8451528bbebbe2dd499687) vmpk: 0.5.1 -> 0.7.2
* [`1133f6e8`](https://github.com/NixOS/nixpkgs/commit/1133f6e86a7d82275aaa05a33f57586637cb69fd) slurp: 1.3.0 -> 1.3.1
* [`b1dc6b0a`](https://github.com/NixOS/nixpkgs/commit/b1dc6b0a29225d6407f8742f71c97c878cf40e62) terraformer: 0.8.8 -> 0.8.9
* [`8d47a25b`](https://github.com/NixOS/nixpkgs/commit/8d47a25b0cbb1fe16bda322ea0fb7466c7c70b60) traefik: 2.3.1 -> 2.3.2
* [`0d4ac477`](https://github.com/NixOS/nixpkgs/commit/0d4ac47717c8815da374ea36764dc71568052f45) ugrep: 2.5.5 -> 3.0.4
* [`cd11c0c8`](https://github.com/NixOS/nixpkgs/commit/cd11c0c817300e151de334b86844d034e77951bb) haskellPackages.hail: relax cabal dependencies to unbreak
* [`bea630e6`](https://github.com/NixOS/nixpkgs/commit/bea630e60698c9779f9335dfd6773d370d409e65) vale: 2.5.0 -> 2.6.1
* [`4534a5e3`](https://github.com/NixOS/nixpkgs/commit/4534a5e36213b55f9942e1e729fbf4ce479ae3ce) vips: 8.10.1 -> 8.10.2
* [`c0599d86`](https://github.com/NixOS/nixpkgs/commit/c0599d86db00c7e65717e7643222ff88eb1ca2a8) wasabiwallet: 1.1.12 -> 1.1.12.2
* [`281a7ba7`](https://github.com/NixOS/nixpkgs/commit/281a7ba7427f1e068cb1d6876005dacc4a1c6d4a) _1password-gui: 0.9.2-1 -> 0.9.3
* [`6818de30`](https://github.com/NixOS/nixpkgs/commit/6818de3026a176271c1cb29f7ada943bac9b9f1c) pythonPackages.urwidtrees: 1.0.2 -> 1.0.3
* [`c5898475`](https://github.com/NixOS/nixpkgs/commit/c589847526735d0c525bb132e850af262cfccc81) viu: 1.1 -> 1.2.1 (nixos/nixpkgs#103582)
* [`bc7a68ac`](https://github.com/NixOS/nixpkgs/commit/bc7a68ac6cdb2ed6c432b676e339a1ce890ed973) rpm-ostree: 2020.5 -> 2020.7
* [`8d8c115d`](https://github.com/NixOS/nixpkgs/commit/8d8c115dbbc8d6064ef546e372406878e9441b2f) inxi: 3.1.08-1 -> 3.1.09-1
* [`457d3469`](https://github.com/NixOS/nixpkgs/commit/457d3469eebe50f13f347870a5ecb408f12af0b0) signal-cli: 0.6.10 -> 0.6.11
* [`aece293e`](https://github.com/NixOS/nixpkgs/commit/aece293ebfe51a19afb41aa64a29840d28c32387) gns3-{gui,server}: 2.2.15 -> 2.2.16
* [`39eadbb3`](https://github.com/NixOS/nixpkgs/commit/39eadbb3c4e1ca48709d0c3d5edfd156450375b7) kubernetes: 1.19.3 -> 1.19.4
* [`6b9f2326`](https://github.com/NixOS/nixpkgs/commit/6b9f23267e4187828e1fbd2a767f87c4e879d5bc) linuxPackages.wireguard: 1.0.20200908 -> 1.0.20201112
* [`d4205544`](https://github.com/NixOS/nixpkgs/commit/d42055441f1a402a37c2387bd1cda23c03e6c9c4) gpxsee: 7.35 → 7.36
* [`03b9d34d`](https://github.com/NixOS/nixpkgs/commit/03b9d34df65b4bb21181b80fc84fbeab703ad701) batsignal: 1.1.3 -> 1.2.0
* [`8fbb662a`](https://github.com/NixOS/nixpkgs/commit/8fbb662a06018735dc0e5ee4ddd99b368eb38fae) gremlin-console: 3.3.4 -> 3.4.8
* [`0c01e11d`](https://github.com/NixOS/nixpkgs/commit/0c01e11ddb97f94ff6adb6b601cd9dc22b94b00d) bazarr: 0.9.0.5 -> 0.9.0.6
* [`47f576ca`](https://github.com/NixOS/nixpkgs/commit/47f576caf80d991ab374eb95a6801f3521ebcc75) k3b: remove qtwebkit dependency (nixos/nixpkgs#103164)
* [`69683ddb`](https://github.com/NixOS/nixpkgs/commit/69683ddbc869c37bbb3fee78b288d81cc82abc6c) armadillo: 10.1.1 -> 10.1.2
* [`4117c0b7`](https://github.com/NixOS/nixpkgs/commit/4117c0b7dfed3b4ada58a00bf2bd8b61357c65d4) tor-browser-bundle-bin: Fix extension path.  Fixes NoScript.
* [`e580eacd`](https://github.com/NixOS/nixpkgs/commit/e580eacd575685539c2f081eaa4ef985317916c1) opencascade-occt: 7.4.0p1 -> 7.5.0
* [`f32beb31`](https://github.com/NixOS/nixpkgs/commit/f32beb311ad822aebedfdb3cec58507f8121231a) ayatana-ido: 0.8.0 -> 0.8.1
* [`e72ebfe7`](https://github.com/NixOS/nixpkgs/commit/e72ebfe79dfd2d10cfce3649f1825e8e4d07cee9) python3Packages.bitstring: 3.1.5 -> 3.1.7
* [`9cb3292b`](https://github.com/NixOS/nixpkgs/commit/9cb3292bdcb2ec9a350b8ceddb990ff29eda4ea2) xmenu: 4.3.1 -> 4.4.1
* [`db215ca0`](https://github.com/NixOS/nixpkgs/commit/db215ca08d68eef7baed7eac090cabc427f6f733) linux_mptcp_94: remove (outdated)
* [`015939be`](https://github.com/NixOS/nixpkgs/commit/015939bece33c8bf973ad7d2634c14b203f78230) linux_mptcp_5_9: MPTCP in upstream linux
* [`950cf2bc`](https://github.com/NixOS/nixpkgs/commit/950cf2bc565a0720f1ec1dd69bd597f972ced16f) python3Packages.setuptools-rust: 0.11.4 -> 0.11.5
* [`1b5a1c69`](https://github.com/NixOS/nixpkgs/commit/1b5a1c697da8269ea49249461ced87662d120924) nixos/tests/postfix: migrate test to use tlsTrustedAuthorities
* [`5b44f469`](https://github.com/NixOS/nixpkgs/commit/5b44f469135d52c5c9205ea5ee8374f57ea9eefb) diffoscope: 160 -> 161
* [`02a1379d`](https://github.com/NixOS/nixpkgs/commit/02a1379d454e5749951604035c17ca2651535691) EmptyEpsilon: 2020.08.07 -> 2020.08.25
* [`e7053a87`](https://github.com/NixOS/nixpkgs/commit/e7053a87adf9fd31362a34c79d54d4e1305d31b8) evcxr: 0.5.3 -> 0.6.0
* [`f94859f1`](https://github.com/NixOS/nixpkgs/commit/f94859f1999f44530b9ea3220e1556702cf9c789) epson-escpr2: 1.1.23 -> 1.1.24
* [`e19567ab`](https://github.com/NixOS/nixpkgs/commit/e19567abb9075df8a4c9e30b75f7dad2ce0c4f59) dino: 0.1.0 -> 0.2.0
* [`93095633`](https://github.com/NixOS/nixpkgs/commit/9309563332a0a8a03447b8a5f1602ffb88b2f7ac) postfix: add passthru tests
* [`c80ddf3b`](https://github.com/NixOS/nixpkgs/commit/c80ddf3b2502ed5d03c1d70abfc67cbf720107d5) makemkv: 1.15.2 -> 1.15.3
* [`f70ecb65`](https://github.com/NixOS/nixpkgs/commit/f70ecb65e71837e1029796d83af253a904ab38b6) python3Packages.fastecdsa: init at 2.1.5
* [`8f4df972`](https://github.com/NixOS/nixpkgs/commit/8f4df972e034a57261fc2fdf114b71728222cdfc) colord: 1.4.4 -> 1.4.5
* [`331e2376`](https://github.com/NixOS/nixpkgs/commit/331e2376cd47b0282bdb30c00e1c506a6759fa13) libplacebo: 2.72.0 -> 2.72.2
* [`9a7e4982`](https://github.com/NixOS/nixpkgs/commit/9a7e4982ddc163fc0cef44deaa6d5a177cb58c67) klayout: 0.26.6 -> 0.26.8
* [`58a906a7`](https://github.com/NixOS/nixpkgs/commit/58a906a7bf05482842cc9688a6a898e59b267de7) iverilog: unstable-2020-08-24 -> unstable-2020-10-24
* [`e80eeae6`](https://github.com/NixOS/nixpkgs/commit/e80eeae690e24302f1a2d74a1c9fae4ff387ffed) yosys: 2020.10.20 -> 0.9+3675 (new version scheme)
* [`bf094b11`](https://github.com/NixOS/nixpkgs/commit/bf094b11b8486268564e2fa43417e0dd5d168933) trellis: 2020.07.27 -> 2020.11.07
* [`a22061ad`](https://github.com/NixOS/nixpkgs/commit/a22061adef027ce9927bdac6a5f66ec3cbb018a1) nextpnr: 2020.08.22 -> 2020.11.10
* [`c1661fa7`](https://github.com/NixOS/nixpkgs/commit/c1661fa7e1a08e2558f9a17c48740a224ff04bd5) magic-vlsi: 8.3.5 -> 8.3.80, co-maintain
* [`b1680e3f`](https://github.com/NixOS/nixpkgs/commit/b1680e3f7193e486782c03d1ced53d8daef047ef) gnomeExtensions.material-shell: 9 -> 10 (nixos/nixpkgs#103628)
* [`2deeb58f`](https://github.com/NixOS/nixpkgs/commit/2deeb58f49480f468adca6b08291322de4dbce6b) soundtouch: 2.1.2 -> 2.2 (nixos/nixpkgs#103382)
