### PR TITLE
niv nixpkgs: update 58f29d3c -> 684e7315

### DIFF
--- a/home/neovim.nix
+++ b/home/neovim.nix
@@ -40,7 +40,7 @@
       vim-polyglot # A collection of language packs for Vim.
       vim-ps1
       vim-puppet
-      vim-rooter # changes the working directory to the project root 
+      vim-rooter # changes the working directory to the project root
       vim-signature # show marks in gutter
       vim-terraform
       vim-test # invoke test runner

--- a/home/neovim.nix
+++ b/home/neovim.nix
@@ -362,14 +362,14 @@
       EOF
 
       lua <<EOF
-      local nvim_lsp = require('nvim_lsp')
+      local lspconfig = require('lspconfig')
       local on_attach = function(_, bufnr)
         require('diagnostic').on_attach()
         require('completion').on_attach()
       end
       local servers = {'jsonls', 'pyls_ms', 'vimls', 'clangd', 'tsserver', 'cssls', 'html'}
       for _, lsp in ipairs(servers) do
-        nvim_lsp[lsp].setup {
+        lspconfig[lsp].setup {
           on_attach = on_attach,
         }
       end

--- a/hosts/_includes/common.nix
+++ b/hosts/_includes/common.nix
@@ -74,15 +74,15 @@
     kernelPackages = pkgs.linuxPackages_latest;
   };
 
-  #nix = {
-  #  distributedBuilds = true;
-  #  buildMachines = [
-  #    {
-  #      hostName = "eu.nixbuild.net";
-  #      system = "x86_64-linux";
-  #      maxJobs = 100;
-  #      supportedFeatures = [ "benchmark" "big-parallel" ];
-  #    }
-  #  ];
-  #};
+  nix = {
+    distributedBuilds = true;
+    buildMachines = [
+      {
+        hostName = "tau.lan.509ely.com";
+        system = "x86_64-linux";
+        maxJobs = 6;
+        supportedFeatures = [ "benchmark" "big-parallel" ];
+      }
+    ];
+  };
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "58f29d3ca8a64e1ff98f63797a3a32584dd5d54b",
-        "sha256": "1wxlqljmdxlsiwqydcl37g3axjs1wczinslg5ya43qpxni6dr8ss",
+        "rev": "684e73157a3da60b2fda44a890783df51f127917",
+        "sha256": "0fcaxqdmh4zchl568z3l6iq4cix37qqkd4bh8227xn73ypbzc346",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/58f29d3ca8a64e1ff98f63797a3a32584dd5d54b.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/684e73157a3da60b2fda44a890783df51f127917.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks.nix": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Commits: [nixos/nixpkgs@58f29d3c...684e7315](https://github.com/nixos/nixpkgs/compare/58f29d3ca8a64e1ff98f63797a3a32584dd5d54b...684e73157a3da60b2fda44a890783df51f127917)

* [`0fb14ea4`](https://github.com/NixOS/nixpkgs/commit/0fb14ea4d36f9cf379ecc9a2ea04c7bf56c54984) terraform-providers.google-beta: 3.18.0 -> 3.47.0
* [`4db23927`](https://github.com/NixOS/nixpkgs/commit/4db239272c36f394416253d6223c70f5391666f2) mullvad-vpn: add iproute2
* [`688c8c03`](https://github.com/NixOS/nixpkgs/commit/688c8c0333b3598c057582ce093fd4da8fa29a23) terraform-providers.postgresql: 1.6.0 -> 1.7.1
* [`ce84cc06`](https://github.com/NixOS/nixpkgs/commit/ce84cc06bf3a6311c67e73b6675fc5c1317dec23) texlive: Use lib.unique for uniqueness checks
* [`22965d84`](https://github.com/NixOS/nixpkgs/commit/22965d84d5e57307d4f6f02d32b50adac2cbb6bb) sssd: fix build on glibc-2.32
* [`c384c540`](https://github.com/NixOS/nixpkgs/commit/c384c5409ac249d4913a21d5b6b8edda8876e26e) linux: 4.14.208 -> 4.14.209
* [`06ba11d0`](https://github.com/NixOS/nixpkgs/commit/06ba11d0b7003f3b1d6fe45b0b67cec555033cea) linux: 4.19.159 -> 4.19.160
* [`d17c554f`](https://github.com/NixOS/nixpkgs/commit/d17c554fdf2f96e8e907325bb3a612ac42c62d3e) linux: 4.4.245 -> 4.4.246
* [`a17655a2`](https://github.com/NixOS/nixpkgs/commit/a17655a29163ecc668b8b0abda729789dd0c8b40) linux: 4.9.245 -> 4.9.246
* [`53738d41`](https://github.com/NixOS/nixpkgs/commit/53738d417f3e9291b514745722ab117bedfe6ff8) linux: 5.4.79 -> 5.4.80
* [`513afc73`](https://github.com/NixOS/nixpkgs/commit/513afc731c0f86507e5da6ab72b12ec93ec41f44) linux: 5.9.10 -> 5.9.11
* [`874e2500`](https://github.com/NixOS/nixpkgs/commit/874e250009b7d7d56a27603b64c4c100f1b4377e) linux-rt_5_4: 5.4.77-rt43 -> 5.4.78-rt44
* [`4de5d2b0`](https://github.com/NixOS/nixpkgs/commit/4de5d2b081c6232c44da91d05d1d7ae38acea34a) influxdb2: init at v2.0.2 (nixos/nixpkgs#104717)
* [`366791e9`](https://github.com/NixOS/nixpkgs/commit/366791e9ca982c029c19fc2c923892a6e966e3f7) golangci-lint: 1.32.2 -> 1.33.0 (nixos/nixpkgs#104768)
* [`54130aa9`](https://github.com/NixOS/nixpkgs/commit/54130aa9de04438f8f6877f2f188a2e1a95d5a7a) dhallPackages.Prelude: 13.0.0 -> 19.0.0
* [`2545e3f3`](https://github.com/NixOS/nixpkgs/commit/2545e3f370ce739aa50c9bcbe01517190d2e4d08) python2Packages.cryptography: mark insecure, CVE-2020-25659
* [`6993bd0b`](https://github.com/NixOS/nixpkgs/commit/6993bd0b56979bdb258c8466cc9ae55e890f8594) rustscan: 1.10.1 -> 2.0.1
* [`0a1c0fe6`](https://github.com/NixOS/nixpkgs/commit/0a1c0fe6589abf7a8f04a97f94a32bf073fed316) k9s: 0.23.10 -> 0.24.1
* [`bc49a081`](https://github.com/NixOS/nixpkgs/commit/bc49a0815ae860010b4d593b02f00ab6f07d50ea) utillinux: rename to util-linux
* [`a0f09270`](https://github.com/NixOS/nixpkgs/commit/a0f0927013eff2ac41b7a306978e1421c7d5721d) vscode: fix opening files with pcmanfm
* [`297d1d6b`](https://github.com/NixOS/nixpkgs/commit/297d1d6b83c92c4f6942c6479f176d8004a819dd) inkscape: add inkcut extension
* [`db432583`](https://github.com/NixOS/nixpkgs/commit/db43258354c4f01adecf6a99dcd8f61e08ea55a2) signal-desktop: 1.38.1 -> 1.38.2
* [`4e721164`](https://github.com/NixOS/nixpkgs/commit/4e721164a807f2dd5ca8b3cdb962f5396afba11d) wlsunset: init at 0.1.0 (nixos/nixpkgs#103606)
* [`32df7801`](https://github.com/NixOS/nixpkgs/commit/32df78017b048729ae336c4c9e81b53c939f0c82) svtplay-dl: 2.7 -> 2.8
* [`18fab623`](https://github.com/NixOS/nixpkgs/commit/18fab62368acb6f28b11cb2f37bf77ada0aa60c4) svtplay-dl: Enable on macOS as well
* [`9a515a9d`](https://github.com/NixOS/nixpkgs/commit/9a515a9d458926c928f00d0bb67fc06e9b2dafbb) svtplay-dl: add ffmpeg as dependency
* [`2044fa17`](https://github.com/NixOS/nixpkgs/commit/2044fa172d75946ec4aceaf2af3f4f3baf0b8280) sssd: fix nss collision with upstream patch
* [`b214b290`](https://github.com/NixOS/nixpkgs/commit/b214b29001989c37b311cbea8beb115e27510616) eksctl: 0.31.0 -> 0.32.0
* [`b660fbbb`](https://github.com/NixOS/nixpkgs/commit/b660fbbbd9cf28d517b24ad329052ed598048e0c) exodus: 20.11.10 -> 20.11.21
* [`fa0fd015`](https://github.com/NixOS/nixpkgs/commit/fa0fd01569b61a32e1ba65ef541d34f526c8a252) bat: 0.17.0 -> 0.17.1
* [`285f69eb`](https://github.com/NixOS/nixpkgs/commit/285f69eb8014d43d787a8a784445cba7a7caeb77) pythonPackages.gradient_statsd: Disable tests
* [`6794b7ee`](https://github.com/NixOS/nixpkgs/commit/6794b7eed69c3309643efa9a09af896a1e9f9a04) nix-update: 0.1 -> 0.2
* [`3873438b`](https://github.com/NixOS/nixpkgs/commit/3873438b8f9379496dcf7600c0839f9a356d4b06) python3Packages.mss: 6.0.0 -> 6.1.0
* [`8d4af2e0`](https://github.com/NixOS/nixpkgs/commit/8d4af2e08c3d161fa482fe8e14af721e79ae7a09) gitAndTools.gh: 1.2.1 -> 1.3.0
* [`ae61f8ac`](https://github.com/NixOS/nixpkgs/commit/ae61f8ac4ddbe73c0f80d1eca7e716c6d3f8197f) gnome3.eog: 3.38.0 -> 3.38.1
* [`d9343445`](https://github.com/NixOS/nixpkgs/commit/d93434458bc85a6ceed303f6b0c58fb3f99d6e29) nixos/factorio: add openFirewall option
* [`3d3bcc5c`](https://github.com/NixOS/nixpkgs/commit/3d3bcc5cc92541e3a63441a3d39f1176ef92c03b) nixos/factorio: Don't open firewall ports by default
* [`edd823b7`](https://github.com/NixOS/nixpkgs/commit/edd823b713c688151b421709130e900813261559) devede: move to GitLab, 4.8.8 -> 4.16.0
* [`19036e0c`](https://github.com/NixOS/nixpkgs/commit/19036e0ca0605d855066a10b650815b45cd76155) opensc: 0.20.0 -> 0.21.0
* [`a52c4f0f`](https://github.com/NixOS/nixpkgs/commit/a52c4f0f712bdc6f0d09cdbbd0b09f740229b498) gnome3.devhelp: 3.38.0 -> 3.38.1
* [`50f6a123`](https://github.com/NixOS/nixpkgs/commit/50f6a123e5ae998bca3c56081dbee1adb091012d) nodejs-12_x: 12.19.1 -> 12.20.0
* [`46f22701`](https://github.com/NixOS/nixpkgs/commit/46f22701be85c50d77f0e2d159cfd5193d31ca61) nodejs-15_x: 15.2.1 -> 15.3.0
* [`b92942f4`](https://github.com/NixOS/nixpkgs/commit/b92942f4668d9bf45df3aead90eddb636ec6db28) systemd: use withPortabled in mesonFlags
* [`3af181d8`](https://github.com/NixOS/nixpkgs/commit/3af181d8a6119811936628fffe02a7d2beccee71) dislocker: 0.7.1 -> 0.7.3
* [`129c30e2`](https://github.com/NixOS/nixpkgs/commit/129c30e26dbe1873697fb73b29f1ee558f6e5b6e) resilio-sync: add aarch64 support
* [`7275a26e`](https://github.com/NixOS/nixpkgs/commit/7275a26ed50f1ffd12732b6c48067f8c9701a7ca) gcompris: 0.98 -> 1.0
* [`5451c908`](https://github.com/NixOS/nixpkgs/commit/5451c908e22d779e34b7a120128e58c4b852ac99) glow: 1.2.0 -> 1.2.1
* [`77c7db03`](https://github.com/NixOS/nixpkgs/commit/77c7db03b2594184e6085ccda2601af48e0fe154) python3Packages.pyHS100: 0.3.5.1 -> 0.3.5.2
* [`7f5dfd2b`](https://github.com/NixOS/nixpkgs/commit/7f5dfd2b84d68a9e9f40253c35fcba69e518048c) evolution-data-server: 3.38.1 -> 3.38.2
* [`668e7a44`](https://github.com/NixOS/nixpkgs/commit/668e7a441a851cc1eb15bcf91b725b3b8ce7dd50) gnome3.gnome-getting-started-docs: 3.36.2 -> 3.38.0
* [`f2b2eb23`](https://github.com/NixOS/nixpkgs/commit/f2b2eb23f1d600de0a008ee3d965e3f62871f975) vips: add librsvg dependency
* [`58b9e10a`](https://github.com/NixOS/nixpkgs/commit/58b9e10a6ed32c9438b8c5b86d3753c1478a8733) flyway: 7.2.0 -> 7.2.1
* [`80b1ecca`](https://github.com/NixOS/nixpkgs/commit/80b1ecca9d0c82c66f794031fa703ffadb0e25ed) cagebreak: 1.4.3 -> 1.4.4
* [`79a91016`](https://github.com/NixOS/nixpkgs/commit/79a91016914b345fb5c68b802638b329054e21df) tmuxp: 1.6.2 -> 1.6.3
* [`72752ab8`](https://github.com/NixOS/nixpkgs/commit/72752ab88ec1835da553460f36e2e6f55da0a7f6) vimwiki-markdown: 0.3.2 -> 0.3.3
* [`9c03664e`](https://github.com/NixOS/nixpkgs/commit/9c03664e4b08fbcc83293d082a00e225f6782195) plex-media-player: remove myself as a maintainer
* [`6849c4a4`](https://github.com/NixOS/nixpkgs/commit/6849c4a4c9b356ec1d8d8a02762a6e6dbf50700c) urh: 2.8.9 -> 2.9.0
* [`3174ae17`](https://github.com/NixOS/nixpkgs/commit/3174ae1723f4eb6d249e88ff4fd02ef816b8b134) mavproxy: 1.8.24 -> 1.8.27
* [`d624e520`](https://github.com/NixOS/nixpkgs/commit/d624e520d0dcb85ffc20d1e2e49331190ccd1404) vcstool: 0.2.14 -> 0.2.15
* [`5603d2eb`](https://github.com/NixOS/nixpkgs/commit/5603d2eb0222795d9b33302db59a563361dfe12f) jira-cli: 2.2 -> 3.0
* [`e40f4acb`](https://github.com/NixOS/nixpkgs/commit/e40f4acb2706513eda92e1c7c92f085162844e01) ocaml: minor refactoring
* [`254f2bad`](https://github.com/NixOS/nixpkgs/commit/254f2bad97c4148aa1a6e2f484d9849a63c5dcfa) ocaml-ng.ocamlPackages_4_12.ocaml: init at 4.12.0-α1
* [`6cea12cc`](https://github.com/NixOS/nixpkgs/commit/6cea12ccff6e279f0bc1f91aa6a898d642e03320) alacritty: 0.6.0-rc1 -> 0.6.0
* [`af10cef5`](https://github.com/NixOS/nixpkgs/commit/af10cef5aab218fb6689b890f9ac21dfbbbc9faa) python37Packages.thinc: 7.4.2 -> 7.4.3
* [`5790bb07`](https://github.com/NixOS/nixpkgs/commit/5790bb073f8cfa5de29ce65ae4c6d15b21cccf7e) nixos auto-upgrade: remove flag when flake
* [`35e50449`](https://github.com/NixOS/nixpkgs/commit/35e50449a3f92632970bcca9aee26100f49c0bfb) python37Packages.trimesh: 3.8.13 -> 3.8.14
* [`c5389c57`](https://github.com/NixOS/nixpkgs/commit/c5389c5729dccdd7ac9883f929a5e4fd2482ef03) gnome-user-docs: 3.38.1 -> 3.38.2
* [`3725f9ed`](https://github.com/NixOS/nixpkgs/commit/3725f9ed9b08c73ee07d7f213abb2c1c22af2509) iosevka: update location of parameters.toml
* [`e8ee6a40`](https://github.com/NixOS/nixpkgs/commit/e8ee6a408fa1869dc648db990eb515d30a764180) gnome3.gnome-music: 3.38.1 -> 3.38.2
* [`03df9f54`](https://github.com/NixOS/nixpkgs/commit/03df9f54fc54a29d14a614bd29323076b5259588) terragrunt: 0.26.4 -> 0.26.5
* [`3ed220fd`](https://github.com/NixOS/nixpkgs/commit/3ed220fd5f6c1519cfd3eb75b174c3c8997c9c2b) gnome3.gedit: 3.38.0 -> 3.38.1
* [`3716bb5e`](https://github.com/NixOS/nixpkgs/commit/3716bb5e6cc562aa4a9c1b66463ac950e961d009) gnome3.gnome-calculator: 3.38.1 -> 3.38.2
* [`cd54ef20`](https://github.com/NixOS/nixpkgs/commit/cd54ef201e7ce2b1e68d63043cee4649c894e923) glade: 3.38.1 -> 3.38.2
* [`2ea6e83a`](https://github.com/NixOS/nixpkgs/commit/2ea6e83af170edbfad0ce7e28f85c1f7275fb7cf) gnome3.gnome-devel-docs: 3.38.1 -> 3.38.2
* [`d75276a2`](https://github.com/NixOS/nixpkgs/commit/d75276a28e60bd3105669eb0da1a13e418c518bd) meli: fix runtime error with libnotmuch5
* [`118695a3`](https://github.com/NixOS/nixpkgs/commit/118695a3500a95038eb9e6dcbf2f6bf09845497d) pass: seperate dmenu from x11Support
* [`0dbd4c98`](https://github.com/NixOS/nixpkgs/commit/0dbd4c98a98b9c3b362792ef23d54732e3d8ae53) viber: 7.0.0.1035 -> 13.3.1.22
* [`f6dfcaa3`](https://github.com/NixOS/nixpkgs/commit/f6dfcaa3c8d077f366c06670de6692a1d2fdccf8) mdds: mark broken on darwin
* [`ff2aface`](https://github.com/NixOS/nixpkgs/commit/ff2afaced1bfc3a98a5e0b05aec7407183121178) rgp: 1.8 -> 1.9
* [`88bc9aba`](https://github.com/NixOS/nixpkgs/commit/88bc9aba99d010495a9f45be6ed161d106b1cb1a) firefox-beta-bin: 81.0b4 -> 84.0b4
* [`41c91ed0`](https://github.com/NixOS/nixpkgs/commit/41c91ed03c3ddbbc42dde49dd05221b9b5542508) firefox-devedition-bin: 80.0b8 -> 84.0b4
* [`7677449d`](https://github.com/NixOS/nixpkgs/commit/7677449d51ed28162d91743a5badccc820d6809b) mpc-qt: Fix compilation failure due to mpv changes
* [`96ce7ccb`](https://github.com/NixOS/nixpkgs/commit/96ce7ccb9310438acb2400b76eac4ee70e957fe5) slirp4netns: 1.1.6 -> 1.1.7
* [`9100dac4`](https://github.com/NixOS/nixpkgs/commit/9100dac4537d50d96401143c1196331f3e6cbe4a) chromedriver: 85.0.4183.87 -> 86.0.4240.22 (nixos/nixpkgs#101974)
* [`bee90bae`](https://github.com/NixOS/nixpkgs/commit/bee90bae9a84305f4c0ac0fab4036ecf85114173) perlPackages.TermReadPassword: init at 0.11
* [`ad62155c`](https://github.com/NixOS/nixpkgs/commit/ad62155cb65a9aa0153dbde5be8698b715003473) nixos/zram: add zramSwap.memoryMax option
* [`6421a1b0`](https://github.com/NixOS/nixpkgs/commit/6421a1b0ceaa820330b883645cb7eb2231b7182c) factorio-experimental, factorio-headless-experimental: 1.1.0 -> 1.1.1
* [`8406e0bc`](https://github.com/NixOS/nixpkgs/commit/8406e0bcd18e24e6db6ddc409ff1dd735d18e809) yubioath-desktop: fix python git dependency (nixos/nixpkgs#104884)
* [`3ae802b3`](https://github.com/NixOS/nixpkgs/commit/3ae802b342dd308d6d836c69bd2c625f51066943) pwntools: 4.2.2 -> 4.3.0
* [`13b8ff4e`](https://github.com/NixOS/nixpkgs/commit/13b8ff4ecf6c3a762965a1825e51de90058c4c9c) fuse-overlayfs: 1.2.0 -> 1.3.0
* [`ac0ac4fe`](https://github.com/NixOS/nixpkgs/commit/ac0ac4fe51080f0815a0bc4928dc2b23c802fdb2) dydisnix: init at unstable (nixos/nixpkgs#49366)
* [`17b13546`](https://github.com/NixOS/nixpkgs/commit/17b13546af84c33634bb966f81064de70a8a0801) mosh: name -> pname
* [`e981d3a4`](https://github.com/NixOS/nixpkgs/commit/e981d3a4484bc2dda7611b51a6528e95a95fde0b) photoflow: 2018-08-28 -> 2020-08-28
* [`d402d913`](https://github.com/NixOS/nixpkgs/commit/d402d913d754469f421572284e00292f83de1af5) bluespec: unstable-2020.02.09 -> unstable-2020.11.04
* [`7afd5050`](https://github.com/NixOS/nixpkgs/commit/7afd50501b66f2faa4f884adbffff55da5f95ff8) python37Packages.jupyterlab-git: 0.22.3 -> 0.23.1
* [`3c72ba68`](https://github.com/NixOS/nixpkgs/commit/3c72ba6898bc92170bc42de10494c86d5eaf36a2) python3Packages.jupyterlab-git: Disable tests on darwin
* [`8fb4c68d`](https://github.com/NixOS/nixpkgs/commit/8fb4c68d7abdf22211ef76f5e57bcbbf64b8630c) python37Packages.genanki: 0.9.0 -> 0.9.1
* [`a120e540`](https://github.com/NixOS/nixpkgs/commit/a120e5404a72506f5f77cd210d4332825e65b92e) python37Packages.smart_open: 3.0.0 -> 4.0.0
* [`a2242b21`](https://github.com/NixOS/nixpkgs/commit/a2242b21c1a8e3e3136a4a21627294de69c8f99c) python37Packages.ha-ffmpeg: 2.0 -> 3.0.2
* [`fd1ed8e9`](https://github.com/NixOS/nixpkgs/commit/fd1ed8e9307accb7da5b958d5325a2668bcbff21) python37Packages.dogpile_cache: 1.1.0 -> 1.1.1
* [`b48d7144`](https://github.com/NixOS/nixpkgs/commit/b48d71446acbcf7563d64fa48e5d819a2bc4006c) mpc-qt: use fetchpatch instead of fetchurl
* [`b41f944e`](https://github.com/NixOS/nixpkgs/commit/b41f944eeb2972d3f072431846a2d06251bb62f6) python37Packages.spacy: 2.3.2 -> 2.3.3
* [`1f1ac382`](https://github.com/NixOS/nixpkgs/commit/1f1ac382b2a14b2ec24e62c999d2074d75537b24) python37Packages.cftime: 1.2.1 -> 1.3.0
* [`e6e0d988`](https://github.com/NixOS/nixpkgs/commit/e6e0d9887736f750332d50cadcd9880ae1c98ac3) executor: 23.1 -> 23.2
* [`c024d24d`](https://github.com/NixOS/nixpkgs/commit/c024d24d4f761d63ce8885e068609b0fc2227d2d) consul: 1.8.5 -> 1.8.6
* [`d26dae67`](https://github.com/NixOS/nixpkgs/commit/d26dae674840ed640ce5cff8382d1a031dc4aa81) omnisharp-roslyn: 1.37.3 -> 1.37.4
* [`f9b2e8f5`](https://github.com/NixOS/nixpkgs/commit/f9b2e8f5793b15709488d8c8fc517af4d27f727b) google-cloud-sdk: 315.0.0 -> 319.0.0 (nixos/nixpkgs#104886)
* [`1ff8d1b1`](https://github.com/NixOS/nixpkgs/commit/1ff8d1b17266b1d16ecacee16207205f17cd8121) python3Packages.botocore: 1.18.18 -> 1.19.25
* [`fce75e16`](https://github.com/NixOS/nixpkgs/commit/fce75e16c9152e9cabfc2bc61664e1d49b9780ce) python3Packages.boto3: 1.15.18 -> 1.16.25
* [`360a14dc`](https://github.com/NixOS/nixpkgs/commit/360a14dcf098642aba17221b698522af4c62aa0b) awscli: 1.18.150 -> 1.18.185
* [`4196aa96`](https://github.com/NixOS/nixpkgs/commit/4196aa9660a3168ef28dd783a0fff4e11695506e) awscli: Add test
* [`e204319c`](https://github.com/NixOS/nixpkgs/commit/e204319c740020330cd657c352d7f29b3d432f5a) pythonPackages.pyscard: Remove patch that is included in 1.9.9 and 2.0.0
* [`66171223`](https://github.com/NixOS/nixpkgs/commit/661712230656a31fdcb4b0e8f4406a2c41197929) gitAndTools.pass-git-helper: 0.4 -> 1.1.0
* [`4e4d498f`](https://github.com/NixOS/nixpkgs/commit/4e4d498ffcb2a1578624b199616b5b3b644d9246) grafana: 7.3.3 -> 7.3.4
* [`9c2351cf`](https://github.com/NixOS/nixpkgs/commit/9c2351cf277734af98220022cceac3c86c54da46) mpv: enable sixel support
* [`2e4d7143`](https://github.com/NixOS/nixpkgs/commit/2e4d714334d77a903fde2c72b69e8ff6e2bb32b8) nixos/tests/networking: Alleviate race in scripted test
* [`fb05770a`](https://github.com/NixOS/nixpkgs/commit/fb05770ac87f3b3c846948dbe780181d6c90612e) httpstat: 1.2.1 -> 1.3.0
* [`c46bb0cc`](https://github.com/NixOS/nixpkgs/commit/c46bb0cca1fff29a3684a493ee1ff096069a33fe) scala: Fix test references
* [`2b714a3d`](https://github.com/NixOS/nixpkgs/commit/2b714a3d58229453766724e971aee9c9fe58a2b3) python37Packages.timeout-decorator: 0.4.1 -> 0.5.0
* [`d4e0e44f`](https://github.com/NixOS/nixpkgs/commit/d4e0e44ff2b5e1274789c1f1d1521b88bc7412ba) pythonPackages.pyscard: Remove unused input
* [`2e3c491a`](https://github.com/NixOS/nixpkgs/commit/2e3c491a00fd707099d7d9acfb44ad96bd977f59) oh-my-zsh: 2020-11-22 → 2020-11-25
* [`ed0d6be5`](https://github.com/NixOS/nixpkgs/commit/ed0d6be5ec5dd9ef07ce9f49053814bced300754) xterm: Add test reference
