### PR TITLE
niv nixpkgs: update c6a8fcd9 -> d26aa329

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c6a8fcd945ae64c5875432dc7e8a6ff112a9c209",
-        "sha256": "1q2nyl55khy9jn705j38wac2cangs7akihn47gr31finimm9pklh",
+        "rev": "d26aa3293c928576eb4b5cee310df5b8ba158c4e",
+        "sha256": "14m63nvni48s5dc6lias6mqj7bs60lfv8phm2qn4kzi9s316rlq8",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/c6a8fcd945ae64c5875432dc7e8a6ff112a9c209.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/d26aa3293c928576eb4b5cee310df5b8ba158c4e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks.nix": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Commits: [nixos/nixpkgs@c6a8fcd9...d26aa329](https://github.com/nixos/nixpkgs/compare/c6a8fcd945ae64c5875432dc7e8a6ff112a9c209...d26aa3293c928576eb4b5cee310df5b8ba158c4e)

* [`2b0ee787`](https://github.com/NixOS/nixpkgs/commit/2b0ee787dd38414101d4b76b5a1818c9a21c57cd) mosquitto: systemd service sandboxing
* [`43b32e6f`](https://github.com/NixOS/nixpkgs/commit/43b32e6f487619a916f71d30dff8d66eacda236a) fractal: mark broken on Darwin
* [`57784466`](https://github.com/NixOS/nixpkgs/commit/5778446619ef4fd1b73e0274d98c387f1151d3ae) bcompare: 4.3.5.24893 -> 4.3.7.25118
* [`921b15ef`](https://github.com/NixOS/nixpkgs/commit/921b15efe75dbde8b6f2e3bb85fe648cba73f0db) python3Packages.nipype: remove Python 2 support (dependency nibabel already unsupported)
* [`f31be2ec`](https://github.com/NixOS/nixpkgs/commit/f31be2ec2576f787811ae1ddd900c322b84a5ab2) python3Packages.nipype: avoid use of neurdflib by default since it causes a package collision when rdflib is in the closure
* [`8d8cd890`](https://github.com/NixOS/nixpkgs/commit/8d8cd8908b58cb7018220d20dd33bea7404fe843) pasystray: ayatana appindicators instead of libappindicator
* [`65c9bb25`](https://github.com/NixOS/nixpkgs/commit/65c9bb252dcfab942fb52038dd0f514479177d4a) clipit: enable appindicator support
* [`ec34ce96`](https://github.com/NixOS/nixpkgs/commit/ec34ce96d089badcb5113cd89d5b844e0704dfd3) pyditz: 0.10.3 -> 0.11
* [`39e33a47`](https://github.com/NixOS/nixpkgs/commit/39e33a47b3dd73c96136bf33f886477c154fef47) mpvScripts.mpris: Use mpv-unwrapped
* [`c69dd499`](https://github.com/NixOS/nixpkgs/commit/c69dd49995325723280851dd70eda359cbc9d8ce) waifu2x-converter-cpp: 5.2.4 -> 5.3.3
* [`ca3dd4b5`](https://github.com/NixOS/nixpkgs/commit/ca3dd4b52f6ffdb9310a9fca2be8a41e413ba857) waifu2x-converter-cpp: add OpenCL support
* [`41e9a530`](https://github.com/NixOS/nixpkgs/commit/41e9a5305bd805ba227377d1b572c1ac30211c0b) powertop: strip hcitool FSH path
* [`ed93d1de`](https://github.com/NixOS/nixpkgs/commit/ed93d1de80e431a7f4c910507495f4e5c8d72296) elementary-planner: 2.4.6 -> 2.5.4
* [`adbe903c`](https://github.com/NixOS/nixpkgs/commit/adbe903c9fc73d96892274eb0ee9129c784d1a2e) jdupes: 1.18.2 -> 1.19.0
* [`58ab512a`](https://github.com/NixOS/nixpkgs/commit/58ab512af3993dd993da3a983ac4badf4098330d) libdigidocpp: 3.14.3 -> 3.14.4
* [`6a1a3207`](https://github.com/NixOS/nixpkgs/commit/6a1a32071ca582212d25ec88000f39a8904ed2c0) keepassrpc: 1.8.0 -> 1.14.0
* [`173bf39c`](https://github.com/NixOS/nixpkgs/commit/173bf39cc28caffc034bba1800bcdb709ce90a98) todoist-electron: 1.23.0 -> 1.24.0
* [`59455622`](https://github.com/NixOS/nixpkgs/commit/59455622b6543c66eed12f372d7cba43c1d79ca6) todoist-electron: Switch to MIT license
* [`8cfeba2b`](https://github.com/NixOS/nixpkgs/commit/8cfeba2bbca84010ef9fa20800efe25d7024a708) todoist-electron: Use desktop icon
* [`3d9ee22d`](https://github.com/NixOS/nixpkgs/commit/3d9ee22da3e3f8673981c39f854e1a538b2c247a) wine{Unstable,Staging}: 5.20 -> 5.21
* [`dfcd45de`](https://github.com/NixOS/nixpkgs/commit/dfcd45de58e124b401fc9c9497c4317433eb7243) wineStable: 5.0.2 -> 5.0.3
* [`152147a8`](https://github.com/NixOS/nixpkgs/commit/152147a8f6548c83d9944a0e6aecd350becfeb09) wine-mono: 4.9.4 -> 5.1.1
* [`22da5d92`](https://github.com/NixOS/nixpkgs/commit/22da5d92aff8f7c962b5d9da9c422b9071104cb3) wine{Unstable,Staging}: 5.21 -> 5.22
* [`4d5ab8d9`](https://github.com/NixOS/nixpkgs/commit/4d5ab8d9f72140348859a3180d98d1983927c070) autofs: fix compilation fail due to libtirpc changes
* [`9144ebaf`](https://github.com/NixOS/nixpkgs/commit/9144ebaf1e4bb906218894d9954a2ecf0bbf1073) wineStable: revert cert-path patch for stable
* [`626f9310`](https://github.com/NixOS/nixpkgs/commit/626f931022580d5afea8281f12a31d375fefb631) wineUnstable: use own set of patches
* [`db17db53`](https://github.com/NixOS/nixpkgs/commit/db17db5318fbb2520f55df888c7c34f570364ecb) nginx: 1.19.4 -> 1.19.5
* [`587ef348`](https://github.com/NixOS/nixpkgs/commit/587ef34841734ddfb8e4acdf03d9cba42876d034) postgresqlPackages.pg_hll: 2.14 -> 2.15
* [`5183864d`](https://github.com/NixOS/nixpkgs/commit/5183864d1863332188e0c1f8fb080beda886c2c3) linux: explicitly enable RAS
* [`d9d8c8a7`](https://github.com/NixOS/nixpkgs/commit/d9d8c8a7fc5c46aff67d500297e3c5a53e055d73) blender: use ffmpeg instead of ffmpeg_3
* [`492f3b80`](https://github.com/NixOS/nixpkgs/commit/492f3b80abad67261d1da0fbc415749f9a51c2ee) blender: fix on darwin
* [`05440fda`](https://github.com/NixOS/nixpkgs/commit/05440fda6f0d922b9084b1f2a64cbc256e7e5ffb) shotcut: use qt-5.15, rework
* [`8f46b51e`](https://github.com/NixOS/nixpkgs/commit/8f46b51e86610892f642ccd51f97a72733d25f54) ammonite: 2.2.0 -> 2.3.8
* [`1b14ab86`](https://github.com/NixOS/nixpkgs/commit/1b14ab86c25adab93d4f97113513efe70b812f49) _1password-gui: 0.9.4-1 -> 0.9.5-2
* [`b3efb719`](https://github.com/NixOS/nixpkgs/commit/b3efb719406b95ab74141c8f71147e8c1dd9a51e) avocode: 4.7.0 -> 4.10.3
* [`92672cff`](https://github.com/NixOS/nixpkgs/commit/92672cfff81e2cc227b237037746ef296c551503) qmapshack: 1.15.0 → 1.15.1
* [`fcbedf65`](https://github.com/NixOS/nixpkgs/commit/fcbedf65aa21e7fa8b437519dd599447f4d35aca) Revert "nmap: 7.80 -> 7.90"
* [`00afc855`](https://github.com/NixOS/nixpkgs/commit/00afc85506c30cd901509aa825e6abf9ed702401) gitter: 4.1.0 -> 5.0.1
* [`63dd41f7`](https://github.com/NixOS/nixpkgs/commit/63dd41f745e7dfcead935bcd5fa008906124d71e) bombadillo: init at 2.3.3
* [`89f75b02`](https://github.com/NixOS/nixpkgs/commit/89f75b02f27ce84e8a402c6845b5bf09df395005) geeqie: 1.4.0 -> 1.5.1
* [`706ed34e`](https://github.com/NixOS/nixpkgs/commit/706ed34eb3321c97b9fdfb35768471537792b4ac) containerd: 1.4.1 -> 1.4.2
* [`3ed321df`](https://github.com/NixOS/nixpkgs/commit/3ed321dfabb152f7c72b6dbcef65374a1c6e7747) z3: enable build on non-x86_64 unix; checked the build on aarch64-linux
* [`06f2fd5f`](https://github.com/NixOS/nixpkgs/commit/06f2fd5fb9f7def14154a7b80e7676e641dd56f9) jetbrains: updates
* [`6aea53c3`](https://github.com/NixOS/nixpkgs/commit/6aea53c3ce3b20c12cbcb61c6f15a744592f3e10) chromedriver: Switch to Chromium's upstream-info.json (nixos/nixpkgs#105054)
* [`abe1271f`](https://github.com/NixOS/nixpkgs/commit/abe1271fe241674afd0b354d6aabfe3bd7e73031) perlPackages.Appcpm: init at 0.994
* [`0229bebd`](https://github.com/NixOS/nixpkgs/commit/0229bebd37caf01cad975090895a5ba2c5973226) cimg: 2.9.3 -> 2.9.4
* [`3546e475`](https://github.com/NixOS/nixpkgs/commit/3546e47583573f7b63b38316bcd675e9856019e2) fondo: 1.3.9 -> 1.3.10
* [`ac3f6009`](https://github.com/NixOS/nixpkgs/commit/ac3f60095b51ab78b35aa445f2667d28d27b8650) pythonPackages.browsermob-proxy: drop insecure python-cryptography transitive dependency; only used for Marionette anyway
* [`0d6bc2f7`](https://github.com/NixOS/nixpkgs/commit/0d6bc2f7c25214ecd83806b38f781c8d3599ce85) broot: 1.0.5 -> 1.0.6
* [`94486021`](https://github.com/NixOS/nixpkgs/commit/9448602120730a5cec867a6e3704c7721c779745) enlightenment.evisum: 0.5.7 -> 0.5.8
* [`64939cff`](https://github.com/NixOS/nixpkgs/commit/64939cff96e1be0dd85ccdfe175e01ada23543ed) neomutt: 20201120 -> 20201127
* [`763e8380`](https://github.com/NixOS/nixpkgs/commit/763e838049c4d5d7e005ed3711998534bb7ea234) ephemeral: 6.4.1 -> 7.0.4
* [`34d28198`](https://github.com/NixOS/nixpkgs/commit/34d2819831d356eb4353658fc7e290d2b0c26eec) ammonite: Fix arguments
* [`f98df98d`](https://github.com/NixOS/nixpkgs/commit/f98df98db3bd87254c9e5d25f9ef032356b2a2fb) google-chrome: Remove msteen from the list of maintainers (nixos/nixpkgs#105152)
* [`eb7d3672`](https://github.com/NixOS/nixpkgs/commit/eb7d36720048f6df6f830ab61f143f823b43e073) runLaTeX: rerun at least twice + refactor (nixos/nixpkgs#104185)
* [`77e367e9`](https://github.com/NixOS/nixpkgs/commit/77e367e9153d4e7b5cc91d5487e569ad85087404) datovka: 4.15.5 -> 4.15.6
* [`09a0f4ca`](https://github.com/NixOS/nixpkgs/commit/09a0f4ca312045fbd1a7962e74e271124ada3054) discord-ptb: 0.0.22 -> 0.0.23
* [`df1c8e3f`](https://github.com/NixOS/nixpkgs/commit/df1c8e3f0f01b6b8996b52f62bfd1d01dcbf8855) python3Packages.snowflake-connector-python: Fix boto3 replace
* [`08c74a2d`](https://github.com/NixOS/nixpkgs/commit/08c74a2d56261a34d5827ffebd820cff4a0bd733) python3Packages.snowflake-sqlalchemy: Disable running tests
* [`d0f04c7c`](https://github.com/NixOS/nixpkgs/commit/d0f04c7c82e3757bfe32940e284ab91bb00cc5b5) frostwire-bin: 6.8.7 -> 6.8.8
* [`67d7a671`](https://github.com/NixOS/nixpkgs/commit/67d7a671799c0d61a5393f2f1076fcbb0d99b5fb) tilt: 0.17.11 -> 0.17.12
