### PR TITLE
niv NUR: update 8dd5adad -> f52fee29

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8dd5adadb3f1ffedeb2f7828921bd01bf55a981a",
-        "sha256": "0cwmylj5npv8dsqwf1zzh0j5xvm37zdb5j76jb5clb1qv8fw4mzf",
+        "rev": "f52fee2966aee11d7f6e3a4011cceafb5dd31323",
+        "sha256": "1k3x734gxwby52f4r2ycjscxnqm3dc4xvz04dxqw9vb02yjysagg",
         "type": "tarball",
-        "url": "https://github.com/nix-community/NUR/archive/8dd5adadb3f1ffedeb2f7828921bd01bf55a981a.tar.gz",
+        "url": "https://github.com/nix-community/NUR/archive/f52fee2966aee11d7f6e3a4011cceafb5dd31323.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "home-manager": {


### PR DESCRIPTION
## Changelog for NUR:
Commits: [nix-community/NUR@8dd5adad...f52fee29](https://github.com/nix-community/NUR/compare/8dd5adadb3f1ffedeb2f7828921bd01bf55a981a...f52fee2966aee11d7f6e3a4011cceafb5dd31323)

* [`7596a504`](https://github.com/nix-community/NUR/commit/7596a5042d4e6d79b4e6f86c78a25bdfa97fc311) add pwnytail's nur-packages repo
* [`34a24eb0`](https://github.com/nix-community/NUR/commit/34a24eb06ef229b37a388f485354724ff7a31258) forgetten ,
* [`e16d5349`](https://github.com/nix-community/NUR/commit/e16d53492004a523c07bb06faa527958f4eb347e) add dukzcry repository
* [`b3a39410`](https://github.com/nix-community/NUR/commit/b3a39410e78cf8d78cbec72143abb22a9de5db91) switch to github actions from travis
* [`b2072fc6`](https://github.com/nix-community/NUR/commit/b2072fc6d06044989c8b087c89b1440a4c36e156) remove travis build status
* [`ec1d8e09`](https://github.com/nix-community/NUR/commit/ec1d8e098573ee91fa1943bf70b2e75de2f120ab) ci: remove ci/test.sh from update action
* [`ec452fca`](https://github.com/nix-community/NUR/commit/ec452fca3f8390599945ae80e93056ebd133c57e) remove pwnytail
* [`943f84be`](https://github.com/nix-community/NUR/commit/943f84be5a48d8fef664fb089699c7f2a9728155) ci: expose github api keys
* [`4f7f115d`](https://github.com/nix-community/NUR/commit/4f7f115d06e674b5fccbc22aa83b54408175d0e5) ci: fix api token passing
* [`dcc01caa`](https://github.com/nix-community/NUR/commit/dcc01caa04f2e9792bf9801fbad390e3d69172f9) ci: try to fix pushing
* [`989ac489`](https://github.com/nix-community/NUR/commit/989ac489534b6e926fce665b79a137e4f664ca7b) ci: fix checkout fetch-depth
* [`ff0cd25b`](https://github.com/nix-community/NUR/commit/ff0cd25b72cf0e797cc03495a813868b4d71211f) fix push url
* [`ed588ba9`](https://github.com/nix-community/NUR/commit/ed588ba93b216505071d6309f7f5646c8b6cc44b) automatic update
* [`f370b731`](https://github.com/nix-community/NUR/commit/f370b731ef1dcd368b6573bc5a9d5a24c298d0c5) ci: make search a seperate job
* [`817aa4b0`](https://github.com/nix-community/NUR/commit/817aa4b0225d31ced76e026d0e3572e3e2ae3c1c) ci: make update_search depend on update_nur
* [`0d4193c1`](https://github.com/nix-community/NUR/commit/0d4193c1b792d5fefc34a1ccc3f19e3043037e23) ci: fix cloning nur-search
* [`fb273b7d`](https://github.com/nix-community/NUR/commit/fb273b7d20942328435df85958b13fdfb3cb200f) ci: fix cloning nur-search
* [`a2a5055c`](https://github.com/nix-community/NUR/commit/a2a5055c92791758f3bb31d47fa54d2afe12c5fc) automatic update
* [`f52fee29`](https://github.com/nix-community/NUR/commit/f52fee2966aee11d7f6e3a4011cceafb5dd31323) automatic update
