### PR TITLE
niv home-manager: update a3a0f128 -> c1faa848

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a3a0f1289acac24ce2ffe0481bf8cabd3a6ccc64",
-        "sha256": "0vkimslwfgv0a71qj93ama71xk5dwp00sb8j67axz1j5nnp0k3nv",
+        "rev": "c1faa848c5224452660cd6d2e0f4bd3e8d206419",
+        "sha256": "1f5dhrj1aqndyf7gh4b6a2i8cafzlx3xdw2cxh4bjhv232cc0hls",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/a3a0f1289acac24ce2ffe0481bf8cabd3a6ccc64.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/c1faa848c5224452660cd6d2e0f4bd3e8d206419.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
## Changelog for home-manager:
Commits: [nix-community/home-manager@a3a0f128...c1faa848](https://github.com/nix-community/home-manager/compare/a3a0f1289acac24ce2ffe0481bf8cabd3a6ccc64...c1faa848c5224452660cd6d2e0f4bd3e8d206419)

* [`c6263347`](https://github.com/nix-community/home-manager/commit/c6263347de7eabf23aa2ebc73baa1a9565b80495) zsh: add initExtraFirst option
* [`c1faa848`](https://github.com/nix-community/home-manager/commit/c1faa848c5224452660cd6d2e0f4bd3e8d206419) tests: update nmt version
