### PR TITLE
niv pre-commit-hooks.nix: update 431227b4 -> 1b11ce0f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "431227b41d0aaa83fabdee6611e145b7d9bd150b",
-        "sha256": "0ff24n8i3mfw0jw5r5lsgvbahmh88zhi3qsk9yxrb8x82jprgzsy",
+        "rev": "1b11ce0f8c65dd3d8e9520e23c100b76d09a858b",
+        "sha256": "0l2v8hsxrvj8w335xxxln49rpd9z5ncv6bl2wnk65zzzd4wa5rkm",
         "type": "tarball",
-        "url": "https://github.com/cachix/pre-commit-hooks.nix/archive/431227b41d0aaa83fabdee6611e145b7d9bd150b.tar.gz",
+        "url": "https://github.com/cachix/pre-commit-hooks.nix/archive/1b11ce0f8c65dd3d8e9520e23c100b76d09a858b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
## Changelog for pre-commit-hooks.nix:
Commits: [cachix/pre-commit-hooks.nix@431227b4...1b11ce0f](https://github.com/cachix/pre-commit-hooks.nix/compare/431227b41d0aaa83fabdee6611e145b7d9bd150b...1b11ce0f8c65dd3d8e9520e23c100b76d09a858b)

* [`b1538c6c`](https://github.com/cachix/pre-commit-hooks.nix/commit/b1538c6c77066bddc241c4ce57a446223776c3d6) Accept nixpkgs and system as arguments
